### PR TITLE
master | LPS-130454

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/ExportUsersMVCResourceCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/ExportUsersMVCResourceCommand.java
@@ -47,6 +47,8 @@ import com.liferay.portlet.usersadmin.search.UserSearch;
 import com.liferay.portlet.usersadmin.search.UserSearchTerms;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
+import java.io.Serializable;
+
 import java.sql.Timestamp;
 
 import java.util.Collections;
@@ -111,8 +113,12 @@ public class ExportUsersMVCResourceCommand extends BaseMVCResourceCommand {
 
 				ExpandoBridge expandoBridge = user.getExpandoBridge();
 
+				Serializable attributeValue = expandoBridge.getAttribute(
+					attributeName);
+
 				sb.append(
-					CSVUtil.encode(expandoBridge.getAttribute(attributeName)));
+					(attributeValue != null) ? CSVUtil.encode(attributeValue) :
+						"");
 			}
 			else if (field.contains("Date")) {
 				Date date = (Date)BeanPropertiesUtil.getObject(user, field);

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueServiceImpl.java
@@ -119,7 +119,8 @@ public class ExpandoValueServiceImpl extends ExpandoValueServiceBaseImpl {
 		ExpandoColumn column = expandoColumnLocalService.getColumn(
 			companyId, className, tableName, columnName);
 
-		if (ExpandoColumnPermissionUtil.contains(
+		if ((column != null) &&
+			ExpandoColumnPermissionUtil.contains(
 				getPermissionChecker(), column, ActionKeys.VIEW)) {
 
 			return expandoValueLocalService.getData(
@@ -138,7 +139,8 @@ public class ExpandoValueServiceImpl extends ExpandoValueServiceBaseImpl {
 		ExpandoColumn column = expandoColumnLocalService.getColumn(
 			companyId, className, tableName, columnName);
 
-		if (!ExpandoColumnPermissionUtil.contains(
+		if ((column == null) ||
+			!ExpandoColumnPermissionUtil.contains(
 				getPermissionChecker(), column, ActionKeys.VIEW)) {
 
 			return null;


### PR DESCRIPTION
These modifications are to handle the uncatched null pointer exception to be able to finish the users export. I decided to return null in the method ExpandoValueServiceImpl.getData because I saw that is the class code's primary strategy. This answer is managed in ExportUsersMVCResourceCommand to generate a correct CSV.