### PR TITLE
master | LPS-136284

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/upgrade/v1_0_0/UpgradePortletPreferences.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/upgrade/v1_0_0/UpgradePortletPreferences.java
@@ -23,6 +23,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.site.navigation.menu.web.internal.constants.SiteNavigationMenuPortletKeys;
 
+import java.util.Arrays;
+import java.util.List;
+
 import javax.portlet.PortletPreferences;
 import javax.portlet.ReadOnlyException;
 
@@ -45,9 +48,15 @@ public class UpgradePortletPreferences
 		String displayStyle = GetterUtil.getString(
 			portletPreferences.getValue("displayStyle", null));
 
+		List<String> displayStyleOutOfTheBox = Arrays.asList(
+			"relative-with-breadcrumb", "from-level-2-with-title",
+			"from-level-1-with-title,from-level-1",
+			"from-level-1-to-all-sublevels", "from-level-0");
+
 		if (Validator.isNull(displayStyle) ||
 			displayStyle.startsWith(
-				PortletDisplayTemplateManager.DISPLAY_STYLE_PREFIX)) {
+				PortletDisplayTemplateManager.DISPLAY_STYLE_PREFIX) ||
+			!displayStyleOutOfTheBox.contains(displayStyle)) {
 
 			return;
 		}


### PR DESCRIPTION
Suppose you have a 6.1 environment with a custom value for the site-navigation-menu-web's displayStyle and you try to upgrade to 7.0+. In that case, the site-navigation-menu-web instances configured with the custom value will lose this configuration. In 7.0, the out-of-the-box values of displayStyle changed, and in the upgrade process, legacy values are changed to the new default value. But it could be interesting that the custom values were maintained to avoid losing this information in the upgrade process.

