### PR TITLE
LPS-135245 | master

### DIFF
--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 5.3.5
+Bundle-Version: 5.4.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/BufferedIndexerInvocationHandlerInternalConfiguration.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/BufferedIndexerInvocationHandlerInternalConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author David Tello
+ */
+@ExtendedObjectClassDefinition(category = "search", generateUI = false)
+@Meta.OCD(
+	id = "com.liferay.portal.search.configuration.BufferedIndexerInvocationHandlerInternalConfiguration"
+)
+public interface BufferedIndexerInvocationHandlerInternalConfiguration {
+
+	@Meta.AD(deflt = "false", required = false)
+	public boolean async();
+
+}

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/index/IndexStatusManager.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/index/IndexStatusManager.java
@@ -23,6 +23,16 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface IndexStatusManager {
 
 	/**
+	 * Returns whether indexing is made in async mode.
+	 *
+	 * @return <code>true</code> if indexing must be done in async mode; <code>false</code>
+	 *         otherwise
+	 * @see    com.liferay.portal.search.configuration.BufferedIndexerInvocationHandlerInternalConfiguration#async(
+	 *         )
+	 */
+	public boolean isAsync();
+
+	/**
 	 * Returns whether all model indexing is disabled.
 	 *
 	 * @return <code>true</code> if indexing is disabled; <code>false</code>

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/configuration/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.4
+version 3.4.0

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/index/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/index/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 3.6.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
@@ -171,7 +171,8 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 		ClassedModel classedModel = (ClassedModel)baseModel.clone();
 
 		IndexerRequest indexerRequest = new IndexerRequest(
-			methodKey.getMethod(), classedModel, _indexer);
+			methodKey.getMethod(), classedModel, _indexer,
+			!_indexStatusManager.isAsync());
 
 		doBufferRequest(indexerRequest, indexerRequestBuffer);
 	}
@@ -192,7 +193,8 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 		}
 
 		IndexerRequest indexerRequest = new IndexerRequest(
-			methodKey.getMethod(), _indexer, className, classPK);
+			methodKey.getMethod(), _indexer, className, classPK,
+			!_indexStatusManager.isAsync());
 
 		doBufferRequest(indexerRequest, indexerRequestBuffer);
 	}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequest.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequest.java
@@ -33,21 +33,22 @@ import java.util.Objects;
 public class IndexerRequest {
 
 	public IndexerRequest(
-		Method method, ClassedModel classedModel, Indexer<?> indexer) {
+		Method method, ClassedModel classedModel, Indexer<?> indexer,
+		boolean foceSync) {
 
 		_method = method;
 		_classedModel = classedModel;
 
 		_indexer = new NoAutoCommitIndexer<>(indexer);
 
-		_forceSync = ProxyModeThreadLocal.isForceSync();
+		_forceSync = foceSync;
 		_modelClassName = classedModel.getModelClassName();
 		_modelPrimaryKey = (Long)_classedModel.getPrimaryKeyObj();
 	}
 
 	public IndexerRequest(
 		Method method, Indexer<?> indexer, String modelClassName,
-		Long modelPrimaryKey) {
+		Long modelPrimaryKey, boolean foceSync) {
 
 		_method = method;
 		_indexer = new NoAutoCommitIndexer<>(indexer);
@@ -55,7 +56,7 @@ public class IndexerRequest {
 		_modelPrimaryKey = modelPrimaryKey;
 
 		_classedModel = null;
-		_forceSync = ProxyModeThreadLocal.isForceSync();
+		_forceSync = foceSync;
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/index/IndexStatusManagerImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/index/IndexStatusManagerImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.IndexStatusManagerThreadLocal;
+import com.liferay.portal.search.configuration.BufferedIndexerInvocationHandlerInternalConfiguration;
 import com.liferay.portal.search.configuration.IndexStatusManagerConfiguration;
 import com.liferay.portal.search.index.IndexStatusManager;
 import com.liferay.portal.search.internal.index.configuration.IndexStatusManagerInternalConfiguration;
@@ -38,12 +39,19 @@ import org.osgi.service.component.annotations.Modified;
  */
 @Component(
 	configurationPid = {
+		"com.liferay.portal.search.configuration.BufferedIndexerInvocationHandlerInternalConfiguration",
 		"com.liferay.portal.search.configuration.IndexStatusManagerConfiguration",
-		"com.liferay.portal.search.internal.index.configuration.IndexStatusManagerInternalConfiguration"
+		"com.liferay.portal.search.internal.index.configuration.IndexStatusManagerInternalConfiguration",
+		"com.liferay.portal.search.internal.index.IndexStatusManagerInternalConfiguration"
 	},
 	immediate = true, service = IndexStatusManager.class
 )
 public class IndexStatusManagerImpl implements IndexStatusManager {
+
+	@Override
+	public boolean isAsync() {
+		return _async;
+	}
 
 	@Override
 	public boolean isIndexReadOnly() {
@@ -141,11 +149,20 @@ public class IndexStatusManagerImpl implements IndexStatusManager {
 
 		_suppressIndexReadOnly =
 			indexStatusManagerInternalConfiguration.suppressIndexReadOnly();
+
+		BufferedIndexerInvocationHandlerInternalConfiguration
+			bufferedIndexerInvocationHandlerInternalConfiguration =
+				ConfigurableUtil.createConfigurable(
+					BufferedIndexerInvocationHandlerInternalConfiguration.class,
+					properties);
+
+		_async = bufferedIndexerInvocationHandlerInternalConfiguration.async();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		IndexStatusManagerImpl.class);
 
+	private volatile boolean _async;
 	private volatile boolean _indexReadOnly;
 	private Throwable _indexReadOnlyCallStackThrowable;
 	private final Set<String> _indexReadOnlyModels = Collections.newSetFromMap(

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/buffer/IndexerRequestBufferHandlerTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/buffer/IndexerRequestBufferHandlerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.internal.buffer;
 
+import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.configuration.IndexerRegistryConfiguration;
@@ -84,7 +85,7 @@ public class IndexerRequestBufferHandlerTest {
 	protected IndexerRequest createIndexerRequest(Indexer<?> indexer) {
 		return new IndexerRequest(
 			_method, indexer, RandomTestUtil.randomString(),
-			RandomTestUtil.randomLong());
+			RandomTestUtil.randomLong(), ProxyModeThreadLocal.isForceSync());
 	}
 
 	protected IndexerRequestBufferExecutorWatcher


### PR DESCRIPTION
Hi Team,

Make sync-asynchronous mode in index write operations configurable.
After analyzing the changes made in the index operations from an asynchronous to the synchronous mode in PTR-2496, it was decided to make this behavior configurable by a portal property.
The changes in the index write operations were made in:

- LPS-127843 (Flip IndexableAdvice to do sync indexing by default, and add a manual switch to allow override. ) already released in 7.3 FP1
- LPS-130001 (Change the default value of ProxyModeThreadLocal#forceSync to TRUE) committed to 7.3.x but not released yet in an FP1

In master, by default, we selected the synchronous mode, but, as Tibor Lipusz told in the PTR, this selection could be changed during the PR review.

After the core team rejects committing the first PR with a general solution, I asked the search team if a more granular solution could be attractive. Andre said the modification could be a good option and suggest some adjustments to the original idea. In this PR I develop all his suggestions and this solution applies only to the search module.