### PR TITLE
master_LPS-140310

### DIFF
--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueServiceImpl.java
@@ -38,7 +38,6 @@ import java.util.Map;
  */
 public class ExpandoValueServiceImpl extends ExpandoValueServiceBaseImpl {
 
-	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
 	@Override
 	public ExpandoValue addValue(
 			long companyId, String className, String tableName,
@@ -55,6 +54,7 @@ public class ExpandoValueServiceImpl extends ExpandoValueServiceBaseImpl {
 			companyId, className, tableName, columnName, classPK, data);
 	}
 
+	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
 	@Override
 	public ExpandoValue addValue(
 			long companyId, String className, String tableName,


### PR DESCRIPTION
Hi team,

This PR only changes the method exposed in the remote API. Exposing the method that uses the Object type to the parameter "data", JSONWS will work with another ExpandoAttribute type than String (for example, Integers). 

If you have any doubts or think this is not the correct way to resolve the issue, please let me know.

Best regards.