### PR TITLE
master | LPS-140310

### DIFF
--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueServiceImpl.java
@@ -38,7 +38,6 @@ import java.util.Map;
  */
 public class ExpandoValueServiceImpl extends ExpandoValueServiceBaseImpl {
 
-	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
 	@Override
 	public ExpandoValue addValue(
 			long companyId, String className, String tableName,
@@ -55,6 +54,7 @@ public class ExpandoValueServiceImpl extends ExpandoValueServiceBaseImpl {
 			companyId, className, tableName, columnName, classPK, data);
 	}
 
+	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
 	@Override
 	public ExpandoValue addValue(
 			long companyId, String className, String tableName,

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoValueService.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoValueService.java
@@ -58,12 +58,12 @@ public interface ExpandoValueService extends BaseService {
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portlet.expando.service.impl.ExpandoValueServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the expando value remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link ExpandoValueServiceUtil} if injection and service tracking are not available.
 	 */
-	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
 	public ExpandoValue addValue(
 			long companyId, String className, String tableName,
 			String columnName, long classPK, Object data)
 		throws PortalException;
 
+	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
 	public ExpandoValue addValue(
 			long companyId, String className, String tableName,
 			String columnName, long classPK, String data)

--- a/portal-kernel/src/com/liferay/expando/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.7.0
+version 1.7.1


### PR DESCRIPTION
Hi team,

This PR only changes the method exposed in the remote API. Exposing the method that uses the Object type to the parameter "data", JSONWS will work with another ExpandoAttribute type than String (for example, Integers).

If you have any doubts or think this is not the correct way to resolve the issue, please let me know.

Best regards.